### PR TITLE
Support for Windows

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile
 import os, sys
-from conans.tools import download, unzip, untargz, replace_in_file, vcvars_command
+from conans.tools import download, unzip, untargz, replace_in_file, vcvars_command, os_info, SystemPackageTool
 from conans import CMake, ConfigureEnvironment
 
 
@@ -14,14 +14,19 @@ class QtConan(ConanFile):
     short_paths = True
 
     def system_requirements(self):
-        if self.settings.os == "Linux": # Further check for debian based missing
-            self.run("sudo apt-get install -y libgl1-mesa-dev libxcb1 libxcb1-dev "
-                     "libx11-xcb1 libx11-xcb-dev libxcb-keysyms1 libxcb-keysyms1-dev "
-                     "libxcb-image0 libxcb-image0-dev libxcb-shm0 libxcb-shm0-dev "
-                     "libxcb-icccm4 libxcb-icccm4-dev libxcb-sync1 libxcb-sync-dev "
-                     "libxcb-xfixes0-dev libxrender-dev libxcb-shape0-dev "
-                     "libxcb-randr0-dev libxcb-render-util0 libxcb-render-util0-dev "
-                     "libxcb-glx0-dev libxcb-xinerama0 libxcb-xinerama0-dev")
+        pack_name = None
+        if os_info.linux_distro == "ubuntu":
+            pack_name = ("libgl1-mesa-dev libxcb1 libxcb1-dev "
+                         "libx11-xcb1 libx11-xcb-dev libxcb-keysyms1 libxcb-keysyms1-dev "
+                         "libxcb-image0 libxcb-image0-dev libxcb-shm0 libxcb-shm0-dev "
+                         "libxcb-icccm4 libxcb-icccm4-dev libxcb-sync1 libxcb-sync-dev "
+                         "libxcb-xfixes0-dev libxrender-dev libxcb-shape0-dev "
+                         "libxcb-randr0-dev libxcb-render-util0 libxcb-render-util0-dev "
+                         "libxcb-glx0-dev libxcb-xinerama0 libxcb-xinerama0-dev")
+        if pack_name:
+            installer = SystemPackageTool()
+            installer.update() # Update the package database
+            installer.install(pack_name) # Install the package
 
     def source(self):
         major = ".".join(self.version.split(".")[:2])

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -7,8 +7,8 @@ username = os.getenv("CONAN_USERNAME", "osechet")
 
 class QtTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    requires = "Qt/5.6.0@%s/%s" % (username, channel)
-    generators = "cmake"
+    requires = "Qt/5.6.1-1@%s/%s" % (username, channel)
+    generators = "cmake", "virtualenv"
 
     def build(self):
         cmake = CMake(self.settings)
@@ -16,5 +16,9 @@ class QtTestConan(ConanFile):
         self.run("cmake --build . %s" % cmake.build_config)
 
     def test(self):
-        self.run("%s %s" % (os.sep.join([".", "bin", "helloworld"]), "conan"))
+        if self.settings.os == "Windows":
+            self.run("activate && %s %s" % (os.sep.join([".", "bin", "helloworld"]), "conan"))
+        else:
+            self.run("%s %s" % (os.sep.join([".", "bin", "helloworld"]), "conan"))
+
 


### PR DESCRIPTION
Proposed changes:

- Package latest patch of 5.6, which would be 5.6.1-1. It is also LTS, and should be the one used for 5.6 deploys
- Use the new (released in conan 0.11) system_requirements, more prepared for multi-distros system requirements, opt-out for sudo usage.
- source() download made generic, so it could serve for future 5.7 packages.
- added -debug -release build flags
- Windows configuration, for several MSVC. Using nmake.
- It seems that ``package()`` is just copying everything inside ``_dist``, so simplified it.
- Using ``env_info`` and ``virtualenv`` generator (new in conan 0.11) to add to the path the directory to find the DLLs shared libraries, without requiring to copy them to the project folder or manually adding them to the system path. Used in the test_package.


I have tested in VS2015, VS2013, Ubuntu16 with gcc 5.4. (I had to merge with your latest changes and solve some conflicts, I hope I have not broken anything, I am re-running, just in case)
