### PR TITLE
skip source copying

### DIFF
--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -2,14 +2,9 @@
 import os
 from conans import ConanFile, CMake
 
-# This easily allows to copy the package in other user or channel
-CHANNEL = os.getenv("CONAN_CHANNEL", "testing")
-USERNAME = os.getenv("CONAN_USERNAME", "osechet")
-
 class QtTestConan(ConanFile):
     """ Qt Conan package test """
 
-    requires = "Qt/5.8.0@%s/%s" % (USERNAME, CHANNEL)
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "virtualenv"
 


### PR DESCRIPTION
Sources are not copied any more from source to build folder, which is allowed thanks to Qt's out of source build feature. As a consequence, we can now get the sources of all modules in the build method, which allows to rebuild various configurations without forcing source method re-execution.