### PR TITLE
Package now relocatable

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -162,10 +162,6 @@ class QtConan(ConanFile):
         env_build = VisualStudioBuildEnvironment(self)
         env.update(env_build.vars)
 
-        # Workaround for conan-io/conan#1408
-        for name, value in env.items():
-            if not value:
-                del env[name]
         with tools.environment_append(env):
             vcvars = tools.vcvars_command(self.settings)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -75,11 +75,11 @@ class QtConan(ConanFile):
         submodules = ["qtbase", "qtrepotools", "qtdeclarative"]
 
         if self.options.activeqt:
-            sumodules.append("qtactiveqt")
+            submodules.append("qtactiveqt")
         if self.options.canvas3d:
             submodules.append("qtcanvas3d")
         if self.options.connectivity:
-            sumodules.append("qtconnectivity")
+            submodules.append("qtconnectivity")
         if self.options.gamepad:
             submodules.append("qtgamepad")
         if self.options.graphicaleffects:
@@ -95,7 +95,7 @@ class QtConan(ConanFile):
         if self.options.tools:
             submodules.append("qttools")
         if self.options.translations:
-            sumodules.append("qttranslations")
+            submodules.append("qttranslations")
         if self.options.webengine:
             submodules.append("qtwebengine")
         if self.options.websockets:

--- a/conanfile.py
+++ b/conanfile.py
@@ -173,8 +173,7 @@ class QtConan(ConanFile):
             else:
                 args += ["-openssl-linked"]
 
-            self.run("cd %s && %s && set" % (self.source_dir, vcvars))
-            self.run("cd %s && %s && configure %s"
+            self.run("cd %s && %s && configure.bat %s"
                      % (self.source_dir, vcvars, " ".join(args)))
             self.run("cd %s && %s && %s %s"
                      % (self.source_dir, vcvars, build_command, " ".join(build_args)))

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,6 +40,7 @@ class QtConan(ConanFile):
     url = "http://github.com/osechet/conan-qt"
     license = "http://doc.qt.io/qt-5/lgpl.html"
     short_paths = True
+    exports_sources = ["qt.conf"]
 
     def system_requirements(self):
         pack_names = None
@@ -226,6 +227,12 @@ class QtConan(ConanFile):
         self.run("cd %s && ./configure %s" % (self.source_dir, " ".join(args)))
         self.run("cd %s && make -j %s" % (self.source_dir, str(cpu_count())))
         self.run("cd %s && make install" % (self.source_dir))
+
+    def package(self):
+        # Qt's installation prefix is hardcoded during the build. In order to
+        # make this package relocatable, we need to provide qt.conf
+        self.copy("qt.conf", dst="bin", keep_path=False)
+
 
     def package_info(self):
         libs = ['Concurrent', 'Core', 'DBus',

--- a/conanfile.py
+++ b/conanfile.py
@@ -122,6 +122,9 @@ class QtConan(ConanFile):
         """ Define your project building. You decide the way of building it
             to reuse it later in any other project.
         """
+        if not os.path.exists(self.package_folder):
+            os.makedirs(self.package_folder)
+
         args = ["-opensource", "-confirm-license", "-nomake examples", "-nomake tests",
                 "-prefix %s" % self.package_folder]
         if not self.options.shared:
@@ -141,17 +144,18 @@ class QtConan(ConanFile):
 
     def _build_msvc(self, args):
         build_command = find_executable("jom.exe")
-        if build_command:
+        if False:
             build_args = ["-j", str(cpu_count())]
         else:
             build_command = "nmake.exe"
             build_args = []
+         
         self.output.info("Using '%s %s' to build" % (build_command, " ".join(build_args)))
 
         env = {}
-        env.update({'PATH': ['%s/qtbase/bin' % self.conanfile_directory,
-                             '%s/gnuwin32/bin' % self.conanfile_directory,
-                             '%s/qtrepotools/bin' % self.conanfile_directory]})
+        env.update({'PATH': ['%s/qtbase/bin' % self.build_folder,
+                             '%s/gnuwin32/bin' % self.build_folder,
+                             '%s/qtrepotools/bin' % self.build_folder]})
         # it seems not enough to set the vcvars for older versions
         if self.settings.compiler == "Visual Studio":
             if self.settings.compiler.version == "14":
@@ -189,10 +193,10 @@ class QtConan(ConanFile):
 
     def _build_mingw(self, args):
         env_build = AutoToolsBuildEnvironment(self)
-        env = {'PATH': ['%s/bin' % self.conanfile_directory,
-                        '%s/qtbase/bin' % self.conanfile_directory,
-                        '%s/gnuwin32/bin' % self.conanfile_directory,
-                        '%s/qtrepotools/bin' % self.conanfile_directory],
+        env = {'PATH': ['%s/bin' % self.build_folder,
+                        '%s/qtbase/bin' % self.build_folder,
+                        '%s/gnuwin32/bin' % self.build_folder,
+                        '%s/qtrepotools/bin' % self.build_folder],
                'QMAKESPEC': 'win32-g++'}
         env.update(env_build.vars)
         with tools.environment_append(env):
@@ -232,7 +236,6 @@ class QtConan(ConanFile):
         # Qt's installation prefix is hardcoded during the build. In order to
         # make this package relocatable, we need to provide qt.conf
         self.copy("qt.conf", dst="bin", keep_path=False)
-
 
     def package_info(self):
         libs = ['Concurrent', 'Core', 'DBus',

--- a/conanfile.py
+++ b/conanfile.py
@@ -72,7 +72,7 @@ class QtConan(ConanFile):
                 self.requires("OpenSSL/1.0.2l@conan/stable")
 
     def source(self):
-        submodules = ["qtbase"]
+        submodules = ["qtbase", "qtrepotools", "qtdeclarative"]
 
         if self.options.activeqt:
             sumodules.append("qtactiveqt")

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,12 +26,17 @@ class QtConan(ConanFile):
         "svg": [True, False],
         "tools": [True, False],
         "translations": [True, False],
+        "declarative": [True, False],
         "webengine": [True, False],
         "websockets": [True, False],
         "xmlpatterns": [True, False],
         "openssl": ["no", "yes", "linked"]
     }
-    default_options = "shared=True", "opengl=desktop", "activeqt=False", "canvas3d=False", "connectivity=False", "gamepad=False", "graphicaleffects=False", "imageformats=False", "location=False", "serialport=False", "svg=False", "tools=False", "translations=False", "webengine=False", "websockets=False", "xmlpatterns=False", "openssl=no"
+    default_options = "shared=True", "opengl=desktop", "activeqt=False", \
+        "canvas3d=False", "connectivity=False", "gamepad=False", "graphicaleffects=False", \
+        "imageformats=False", "location=False", "serialport=False", "svg=False", "tools=False", \
+        "translations=False", "declarative=False", "webengine=False", "websockets=False", \
+        "xmlpatterns=False", "openssl=no"
     url = "http://github.com/osechet/conan-qt"
     license = "http://doc.qt.io/qt-5/lgpl.html"
     short_paths = True
@@ -72,7 +77,7 @@ class QtConan(ConanFile):
                 self.requires("OpenSSL/1.0.2l@conan/stable")
 
     def source(self):
-        submodules = ["qtbase", "qtrepotools", "qtdeclarative"]
+        submodules = ["qtbase", "qtrepotools"]
 
         if self.options.activeqt:
             submodules.append("qtactiveqt")
@@ -96,6 +101,8 @@ class QtConan(ConanFile):
             submodules.append("qttools")
         if self.options.translations:
             submodules.append("qttranslations")
+        if self.options.declarative:
+            submodules.append("qtdeclarative")
         if self.options.webengine:
             submodules.append("qtwebengine")
         if self.options.websockets:

--- a/qt.conf
+++ b/qt.conf
@@ -1,0 +1,2 @@
+[Paths]
+Prefix = ..

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -9,8 +9,6 @@ if(APPLE)
     set(CMAKE_SKIP_RPATH 0)
 endif(APPLE)
 
-configure_file(qt.conf.in ${CMAKE_BINARY_DIR}/bin/qt.conf)
-
 find_package(Qt5Core REQUIRED)
 
 set(CMAKE_AUTOMOC ON)

--- a/test_package/qt.conf.in
+++ b/test_package/qt.conf.in
@@ -1,2 +1,0 @@
-[Paths]
-Prefix = @CONAN_QTBASE_ROOT@


### PR DESCRIPTION
Qt compiles in the installation path. If you move the installation, qmake can no longer locate various files. The prefix path can be overriden with qt.conf.

Previously, the recipe put the onus on the package consumer to create a qt.conf file. It was unclear to the consumer that this should be done and it meant the Qt installation could not be used stand-alone or with QtCreator without jumping through hoops.

The package step now creates a qt.conf in the bin directory, thus making the package relocatable.